### PR TITLE
Hyperlink sequencing

### DIFF
--- a/bin/support/hyperlink.rb
+++ b/bin/support/hyperlink.rb
@@ -29,12 +29,20 @@ def hyperlink(file, domain, link_dictionary)
         content = urls.join(", ")
       else 
         link_dictionary.each do |term, link_address|
-          next if file.match(/#{link_address}\.json$/) # never hyperlink a file to itself
-          content = content.sub( # only hyperlink the first occurrence of a given within a section
-            /(^|\s|\()#{term}($|\.|\)|\s|')/i, # match the term if it's preceded+followed by a space, period, \n etc.
-            "\\1[#{term}](#{domain}#{link_address})\\2"
-          )
+          if file.match(/#{link_address}\.json$/) # if this term would hyper link to itself
+            # put a "!!" in front of it so that it doesn't get picked up by any other matches
+            content = content.gsub(
+              /(^|\s|\()#{term}($|\.|\)|\s|')/i, 
+              "\\1!!#{term}\\2"
+            )  
+          else
+            content = content.sub( # only hyperlink the first occurrence of a given within a section
+              /(^|\s|\()#{term}($|\.|\)|\s|')/i, # match the term if it's preceded+followed by a space, period, \n etc.
+              "\\1[#{term}](#{domain}#{link_address})\\2"
+            )
+          end
         end
+         content = content.gsub(/!!/, "") # remove all "!!" used to remove self linking terms from the link pool
       end
     end
     transformed_file_values[header] = content

--- a/bin/support/link_dictionary.rb
+++ b/bin/support/link_dictionary.rb
@@ -23,13 +23,29 @@ files.each do |file|
     section_content = sections[section]
     if section_content
       section_content.split(",").each do |link_key|
-        link_key = link_key.strip
+        link_key = link_key.strip.downcase
         link_dictionary[link_key] = link_value
         pluralized_link_key = "#{link_key}s" # poor yet comprehensible attempt at pluralizing for now
         link_dictionary[pluralized_link_key] = link_value
       end
     end
   end
+end
+
+substring_keys = [] # keys that are a substring of another key. E.g., the key "Dapp" is a substring of the key "Dapp Platform"
+link_dictionary.each do |link_key_a|
+  link_dictionary.each do |link_key_b|
+    if link_key_b.include?(link_key_a)
+      substring_keys << link_key_a
+    end
+  end
+end
+
+# Set these substring keys as the last keys in the link dictionary so that keys like "Dapp Platform" get hyperlinked before keys like "Dapp" do.
+substring_keys.each do |key|
+  value = link_dictionary[key]
+  link_dictionary.delete[key]
+  link_dictionary[key] = value
 end
 
 puts link_dictionary.to_json


### PR DESCRIPTION
This pr:

1) Automatically sequences hyperlinkable terms such that substrings like “Dapp” only get linked after superstrings like “Dapp Platform” do

2) Ensures that superstring links (e.g. “Bitcoin Cash”) box out substring links (e.g. “Bitcoin”) in their own files where they wouldn’t they wouldn’t otherwise be linked.